### PR TITLE
Ruby have no method called `array`

### DIFF
--- a/lib/Paymentwall/Widget.rb
+++ b/lib/Paymentwall/Widget.rb
@@ -3,7 +3,7 @@ module Paymentwall
 		
 		BASE_URL = 'https://api.paymentwall.com/api'
 
-		def initialize(userId, widgetCode, products = array(), extraParams = {})
+		def initialize(userId, widgetCode, products = [], extraParams = {})
 			@userId = userId
 			@widgetCode = widgetCode
 			@extraParams = extraParams


### PR DESCRIPTION
When you create a new widget with default values for products list it fails with error:

``` ruby
Paymentwall::Widget.new('123', '123')
NoMethodError: undefined method `array' for #<Paymentwall::Widget:0x0000000cec02c8>
```
