### PR TITLE
Add new IP address range to whitelisted ips.

### DIFF
--- a/features/pingback.feature
+++ b/features/pingback.feature
@@ -19,6 +19,22 @@ Scenario: check Digital Goods pingback signature v2 with correct signature and c
   And Pingback method "isDeliverable" should return "true"
   And Pingback method "isCancelable" should return "false"
 
+Scenario: check Digital Goods pingback signature v2 with correct signature and correct new IP
+  Given Public key "c22f895840bf2391f67a40da64bfed26"
+  And Secret key "a7408723eaf4bfa2e3ac49b3cb695046"
+  And API type "2"
+  And Pingback GET parameters "uid=test_user&goodsid=test_product&slength=5&speriod=month&type=0&ref=t123&is_test=1&sign_version=2&sig=754cff93c0eb859f6054bef143ad253c"
+  And Pingback IP address "216.127.71.186"
+  When Pingback is constructed
+  Then Pingback validation result should be "true"
+  And Pingback method "getUserId" should return "test_user"
+  And Pingback method "getProductId" should return "test_product"
+  And Pingback method "getProductPeriodLength" should return "5"
+  And Pingback method "getProductPeriodType" should return "month"
+  And Pingback method "getReferenceId" should return "t123"
+  And Pingback method "isDeliverable" should return "true"
+  And Pingback method "isCancelable" should return "false"
+
 Scenario: check Digital Goods pingback signature v2 with correct signature and wrong IP
   Given Public key "c22f895840bf2391f67a40da64bfed26"
   And Secret key "a7408723eaf4bfa2e3ac49b3cb695046"
@@ -43,6 +59,19 @@ Scenario: check Digital Goods negative pingback signature v3 with correct signat
   And API type "2"
   And Pingback GET parameters "uid=test_user&goodsid=test_product&slength=-5&speriod=month&type=2&ref=t123&is_test=1&reason=9&sign_version=3&sig=2f67209c3e581313a70de9425efef49f35a74c0cdb7f93051b47e3c097011a71"
   And Pingback IP address "174.36.92.186"
+  When Pingback is constructed
+  Then Pingback validation result should be "true"
+  And Pingback method "getProductPeriodLength" should return "-5"
+  And Pingback method "getProductPeriodType" should return "month"
+  And Pingback method "isDeliverable" should return "false"
+  And Pingback method "isCancelable" should return "true"
+
+Scenario: check Digital Goods negative pingback signature v3 with correct signature and correct new IP
+  Given Public key "c22f895840bf2391f67a40da64bfed26"
+  And Secret key "a7408723eaf4bfa2e3ac49b3cb695046"
+  And API type "2"
+  And Pingback GET parameters "uid=test_user&goodsid=test_product&slength=-5&speriod=month&type=2&ref=t123&is_test=1&reason=9&sign_version=3&sig=2f67209c3e581313a70de9425efef49f35a74c0cdb7f93051b47e3c097011a71"
+  And Pingback IP address "216.127.71.186"
   When Pingback is constructed
   Then Pingback validation result should be "true"
   And Pingback method "getProductPeriodLength" should return "-5"

--- a/lib/Paymentwall/Pingback.rb
+++ b/lib/Paymentwall/Pingback.rb
@@ -10,11 +10,11 @@ module Paymentwall
 	    PINGBACK_TYPE_RISK_REVIEWED_DECLINED = 202
 
 	    PINGBACK_TYPE_RISK_AUTHORIZATION_VOIDED = 203
-	    
+
 	    PINGBACK_TYPE_SUBSCRIPTION_CANCELLED = 12
 	    PINGBACK_TYPE_SUBSCRIPTION_EXPIRED = 13
 	    PINGBACK_TYPE_SUBSCRIPTION_FAILED = 14
-		
+
 		def initialize(parameters = {}, ipAddress = '')
 			@parameters = parameters
 			@ipAddress = ipAddress
@@ -27,7 +27,7 @@ module Paymentwall
 				if self.isIpAddressValid() || skipIpWhitelistCheck
 					if self.isSignatureValid()
 						validated = true
-					else 
+					else
 						self.appendToErrors('Wrong signature')
 					end
 				else
@@ -55,7 +55,7 @@ module Paymentwall
 				signatureParams.each do |field|
 					signatureParamsToSign[field] = @parameters.include?(field) ? @parameters[field] : nil
 				end
-				
+
 				@parameters['sign_version'] = self.class::SIGNATURE_VERSION_1
 
 			else
@@ -63,7 +63,7 @@ module Paymentwall
 			end
 
 			signatureCalculated = self.calculateSignature(signatureParamsToSign, self.class::getSecretKey(), @parameters['sign_version'])
-			
+
 			signature = @parameters.include?('sig') ? @parameters['sig'] : nil
 
 			signature == signatureCalculated
@@ -77,6 +77,8 @@ module Paymentwall
 				'174.36.92.192',
 				'174.37.14.28'
 			]
+
+			ipsWhitelist.push(*(0..255).map { |n| "216.127.71.#{n}" })
 
 			ipsWhitelist.include? @ipAddress
 		end
@@ -106,7 +108,7 @@ module Paymentwall
 		def getParameter(param)
 			if @parameters.include?(param)
 				return @parameters[param]
-			else 
+			else
 				return nil
 			end
 		end
@@ -188,7 +190,7 @@ module Paymentwall
 		end
 
 		def isDeliverable()
-			self.getType() == self.class::PINGBACK_TYPE_REGULAR || 
+			self.getType() == self.class::PINGBACK_TYPE_REGULAR ||
 			self.getType() == self.class::PINGBACK_TYPE_GOODWILL ||
 			self.getType() == self.class::PINGBACK_TYPE_RISK_REVIEWED_ACCEPTED
 		end
@@ -205,7 +207,7 @@ module Paymentwall
 		protected
 
 		def calculateSignature(params, secret, version)
-			
+
 			params = params.clone
 			params.delete('sig')
 
@@ -214,7 +216,7 @@ module Paymentwall
 
 			baseString = ''
 
-			keys.each do |name| 
+			keys.each do |name|
 				p = params[name]
 
 				# converting array to hash
@@ -225,7 +227,7 @@ module Paymentwall
 				if p.kind_of?(Hash)
 					subKeys = sortKeys ? p.keys.sort : p.keys;
 					subKeys.each do |key|
-						value = p[key] 
+						value = p[key]
 						baseString += "#{name}[#{key}]=#{value}"
 					end
 				else
@@ -238,7 +240,7 @@ module Paymentwall
 			require 'digest'
 			if version.to_i == self.class::SIGNATURE_VERSION_3
 				return Digest::SHA256.hexdigest(baseString)
-			else 
+			else
 				return Digest::MD5.hexdigest(baseString)
 			end
 		end


### PR DESCRIPTION
From **November 7th, 2018, 12:00 PM GMT**, Pingback payment notifications will started to be sent from a new IP address range that should be whitelisted.

_Source_: https://docs.paymentwall.com/reference/pingback-new-ip-subnet